### PR TITLE
Fix string arguments in query

### DIFF
--- a/lib/query.py
+++ b/lib/query.py
@@ -44,7 +44,7 @@ class Query:
             sel='col{}'.format(self.sel_index),
         )
         if self.conditions:
-            rep +=  ' WHERE ' + ' AND '.join(['{} {} {}'.format('col{}'.format(i), self.cond_ops[o], v) for i, o, v in self.conditions])
+            rep +=  ' WHERE ' + ' AND '.join(['{} {} {}'.format('col{}'.format(i), self.cond_ops[o], '\"' + v + '\"' if isinstance(v, str) else v) for i, o, v in self.conditions])
         return rep
 
     def to_dict(self):


### PR DESCRIPTION
Check the last query in `dev.jsonl` for example
It'll be:
```
SELECT  col4 FROM table WHERE col3 = democratic AND col2 = new york AND col0 = terence j. quinn
```
instead of:
```
SELECT  col4 FROM table WHERE col3 = "democratic" AND col2 = "new york" AND col0 = "terence j. quinn"
```