### PR TITLE
remove unnecessary RUN layer

### DIFF
--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,6 +1,5 @@
 FROM python:3.6.2-alpine
 
-RUN mkdir -p /eval
 WORKDIR /eval
 ADD . /eval/
 


### PR DESCRIPTION
WORKDIR makes a new directory by default, so this command is unnecessary